### PR TITLE
Update to VPSDK 20231217

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN dotnet publish "VPLink.csproj" -c Release -o /app/publish
 
 FROM base AS vpsdk
 WORKDIR /vpsdk
-ADD http://static.virtualparadise.org/dev-downloads/vpsdk_20210802_5afc54ae_linux_debian-stretch_x86_64.tar.gz ./vpsdk.tar.gz
-RUN echo "9156B19DD83D2E2290F6C49228C99320478758C41D958E50030078A62DB6417B vpsdk.tar.gz" | sha256sum -c -&& \
+ADD http://static.virtualparadise.org/dev-downloads/vpsdk_20231217_422bcbfc_linux_debian10_x86_64.tar.gz ./vpsdk.tar.gz
+RUN echo "5F5710EEFC1FC2C5246434A52B9DC05F477A6EFE91394001FAA4097F5CA7BC77 vpsdk.tar.gz" | sha256sum -c -&& \
     tar xfv vpsdk.tar.gz --strip-components=1 && \
     rm -r vpsdk.tar.gz include
 


### PR DESCRIPTION
Relevant changes:
- Fixes `Unknown message type: 28` messages in stdout
- Fixes partially corrupted connection after sending larger messages (see 0.4.6 release notes)